### PR TITLE
fix: HCL Body Parsing

### DIFF
--- a/deploy/app/main.tf
+++ b/deploy/app/main.tf
@@ -19,7 +19,7 @@ module "lambda_sg" {
 
   ingress_cidr_blocks = ["${data.aws_vpc.vpc.cidr_block}"]
   ingress_rules       = ["all-all"]
-  egress_rules        = ["http-80-tcp"]
+  egress_rules        = ["nomad-http-tcp"]
 }
 
 module "lambda_function" {


### PR DESCRIPTION
This PR improves the Lambda handler to ensure compatibility with API Gateway's proxy behavior:

- Adds support for x-api-key as a fallback when Authorization is missing.
- Normalizes Content-Type header (case-insensitive) to support various client and gateway configurations.
- Decodes base64-encoded request bodies when request.IsBase64Encoded is true.
- Fixes a bug where the HCL was being parsed from resp.Body instead of the actual request body.
- Adds basic inline comments to clarify key logic blocks (auth, content type, decoding, parsing, etc.).

These changes ensure reliable behavior when using curl --data-binary or API Gateway's binary mode with HCL job specs.